### PR TITLE
#5381 - scoring server timeout

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -158,6 +158,12 @@ def build_docker(model_uri, name, timeout, install_mlflow, enable_mlserver):
 
         docker run -p 5001:8080 "my-image-name"
 
+    Also we can set an alternative timeout (default: 60) for the scoring server
+
+    .. code:: bash
+
+        docker run -p 5001:8080 -t 120 "my-image-name"
+
     NB: by default, the container will start nginx and gunicorn processes. If you don't need the
     nginx process to be started (for instance if you deploy your container to Google Cloud Run),
     you can disable it via the DISABLE_NGINX environment variable:

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -28,12 +28,20 @@ def commands():
 @cli_args.MODEL_URI
 @cli_args.PORT
 @cli_args.HOST
+@cli_args.TIMEOUT
 @cli_args.WORKERS
 @cli_args.NO_CONDA
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
 def serve(
-    model_uri, port, host, workers, no_conda=False, install_mlflow=False, enable_mlserver=False
+    model_uri,
+    port,
+    host,
+    timeout,
+    workers,
+    no_conda=False,
+    install_mlflow=False,
+    enable_mlserver=False,
 ):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port.
@@ -56,7 +64,9 @@ def serve(
     """
     return _get_flavor_backend(
         model_uri, no_conda=no_conda, workers=workers, install_mlflow=install_mlflow
-    ).serve(model_uri=model_uri, port=port, host=host, enable_mlserver=enable_mlserver)
+    ).serve(
+        model_uri=model_uri, port=port, host=host, timeout=timeout, enable_mlserver=enable_mlserver
+    )
 
 
 @commands.command("predict")
@@ -127,9 +137,10 @@ def prepare_env(model_uri, no_conda, install_mlflow):
 @commands.command("build-docker")
 @cli_args.MODEL_URI
 @click.option("--name", "-n", default="mlflow-pyfunc-servable", help="Name to use for built image")
+@cli_args.TIMEOUT
 @cli_args.INSTALL_MLFLOW
 @cli_args.ENABLE_MLSERVER
-def build_docker(model_uri, name, install_mlflow, enable_mlserver):
+def build_docker(model_uri, name, timeout, install_mlflow, enable_mlserver):
     """
     Builds a Docker image whose default entrypoint serves the specified MLflow
     model at port 8080 within the container, using the 'python_function' flavor.
@@ -163,6 +174,7 @@ def build_docker(model_uri, name, install_mlflow, enable_mlserver):
     _get_flavor_backend(model_uri, docker_build=True).build_image(
         model_uri,
         name,
+        timeout=timeout,
         mlflow_home=mlflow_home,
         install_mlflow=install_mlflow,
         enable_mlserver=enable_mlserver,

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -37,6 +37,7 @@ SUPPORTED_FLAVORS = [pyfunc.FLAVOR_NAME, mleap.FLAVOR_NAME]
 
 DISABLE_NGINX = "DISABLE_NGINX"
 ENABLE_MLSERVER = "ENABLE_MLSERVER"
+SERVER_TIMEOUT = "SERVER_TIMEOUT"
 
 SERVING_ENVIRONMENT = "SERVING_ENVIRONMENT"
 
@@ -133,6 +134,7 @@ def _serve_pyfunc(model):
     disable_nginx = os.getenv(DISABLE_NGINX, "false").lower() == "true"
     enable_mlserver = os.getenv(ENABLE_MLSERVER, "false").lower() == "true"
     disable_env_creation = os.environ.get(DISABLE_ENV_CREATION) == "true"
+    timeout = os.environ.get(SERVER_TIMEOUT) == 60
 
     conf = model.flavors[pyfunc.FLAVOR_NAME]
     bash_cmds = []
@@ -171,7 +173,9 @@ def _serve_pyfunc(model):
     # Since MLServer will run without NGINX, expose the server in the `8080`
     # port, which is the assumed "public" port.
     port = DEFAULT_MLSERVER_PORT if enable_mlserver else DEFAULT_INFERENCE_SERVER_PORT
-    cmd, cmd_env = inference_server.get_cmd(model_uri=MODEL_PATH, nworkers=cpu_count, port=port)
+    cmd, cmd_env = inference_server.get_cmd(
+        model_uri=MODEL_PATH, nworkers=cpu_count, port=port, timeout=timeout
+    )
 
     bash_cmds.append(cmd)
     inference_server_process = Popen(["/bin/bash", "-c", " && ".join(bash_cmds)], env=cmd_env)

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -33,7 +33,7 @@ RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.s
 RUN bash ./miniconda.sh -b -p /miniconda && rm ./miniconda.sh
 ENV PATH="/miniconda/bin:$PATH"
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-ENV GUNICORN_CMD_ARGS="--timeout 60 -k gevent"
+ENV GUNICORN_CMD_ARGS="--timeout {server_timeout} -k gevent"
 # Set up the program in the image
 WORKDIR /opt/mlflow
 
@@ -77,13 +77,16 @@ def _get_mlflow_install_step(dockerfile_context_dir, mlflow_home):
         ).format(version=mlflow.version.VERSION)
 
 
-def _build_image(image_name, entrypoint, mlflow_home=None, custom_setup_steps_hook=None):
+def _build_image(
+    image_name, entrypoint, server_timeout, mlflow_home=None, custom_setup_steps_hook=None
+):
     """
     Build an MLflow Docker image that can be used to serve a
     The image is built locally and it requires Docker to run.
 
     :param image_name: Docker image name.
     :param entry_point: String containing ENTRYPOINT directive for docker image
+    :param server_timeout: Scoring server timeout
     :param mlflow_home: (Optional) Path to a local copy of the MLflow GitHub repository.
                         If specified, the image will install MLflow from this directory.
                         If None, it will install MLflow from pip.
@@ -99,6 +102,7 @@ def _build_image(image_name, entrypoint, mlflow_home=None, custom_setup_steps_ho
         with open(os.path.join(cwd, "Dockerfile"), "w") as f:
             f.write(
                 _DOCKERFILE_TEMPLATE.format(
+                    server_timeout=server_timeout,
                     install_mlflow=install_mlflow,
                     custom_setup_steps=custom_setup_steps,
                     entrypoint=entrypoint,

--- a/mlflow/models/flavor_backend.py
+++ b/mlflow/models/flavor_backend.py
@@ -35,13 +35,14 @@ class FlavorBackend:
         pass
 
     @abstractmethod
-    def serve(self, model_uri, port, host, enable_mlserver):
+    def serve(self, model_uri, port, host, timeout, enable_mlserver):
         """
         Serve the specified MLflow model locally.
 
         :param model_uri: URI pointing to the MLflow model to be used for scoring.
         :param port: Port to use for the model deployment.
         :param host: Host to use for the model deployment. Defaults to ``localhost``.
+        :param timeout: Timeout in seconds to serve a request. Defaults to 60.
         :param enable_mlserver: Whether to use MLServer or the local scoring server.
         """
         pass

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -349,13 +349,13 @@ def _serve(model_uri, port, host):
 
 
 def get_cmd(
-    model_uri: str, port: int = None, host: int = None, nworkers: int = None
+    model_uri: str, port: int = None, host: int = None, timeout: int = None, nworkers: int = None
 ) -> Tuple[str, Dict[str, str]]:
     local_uri = path_to_local_file_uri(model_uri)
     # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
     # platform compatibility.
     if os.name != "nt":
-        args = ["--timeout=60"]
+        args = [f"--timeout={timeout}"]
         if port and host:
             args.append(f"-b {host}:{port}")
         elif host:
@@ -370,6 +370,9 @@ def get_cmd(
         )
     else:
         args = []
+        if timeout:
+            args.append(f"--timeout={timeout}")
+
         if host:
             args.append(f"--host={host}")
 

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -37,7 +37,7 @@ class RFuncBackend(FlavorBackend):
         )
         _execute(command)
 
-    def serve(self, model_uri, port, host, enable_mlserver):
+    def serve(self, model_uri, port, host, timeout, enable_mlserver):
         """
         Generate R model locally.
 
@@ -47,6 +47,9 @@ class RFuncBackend(FlavorBackend):
         """
         if enable_mlserver:
             raise Exception("The MLServer inference server is not yet supported in the R backend.")
+
+        if timeout:
+            raise Exception("Timeout is not yet supported in the R backend.")
 
         model_path = _download_artifact_from_uri(model_uri)
         command = "mlflow::mlflow_rfunc_serve('{0}', port = {1}, host = '{2}')".format(

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -567,8 +567,9 @@ def run_local(model_uri, port, image, flavor):
 @click.option("--build/--no-build", default=True, help="Build the container if set.")
 @click.option("--push/--no-push", default=True, help="Push the container to AWS ECR if set.")
 @click.option("--container", "-c", default=IMAGE, help="image name")
+@click.option("--server-timeout", "-t", default=60, help="Set scoring server timeout")
 @cli_args.MLFLOW_HOME
-def build_and_push_container(build, push, container, mlflow_home):
+def build_and_push_container(build, push, container, server_timeout, mlflow_home):
     """
     Build new MLflow Sagemaker image, assign it a name, and push to ECR.
 
@@ -596,6 +597,7 @@ def build_and_push_container(build, push, container, mlflow_home):
         mlflow.models.docker_utils._build_image(
             container,
             mlflow_home=os.path.abspath(mlflow_home) if mlflow_home else None,
+            server_timeout=server_timeout,
             entrypoint=sagemaker_image_entrypoint,
             custom_setup_steps_hook=setup_container,
         )

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -73,6 +73,10 @@ HOST = click.option(
 
 PORT = click.option("--port", "-p", default=5000, help="The port to listen on (default: 5000).")
 
+TIMEOUT = click.option(
+    "--timeout", "-t", default=60, help="Timeout in seconds to serve a request (default: 60)."
+)
+
 # We use None to disambiguate manually selecting "4"
 WORKERS = click.option(
     "--workers",

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -466,10 +466,10 @@ def test_parse_with_schema(pandas_df_with_all_types):
     assert df["bad_float"].dtype == np.float32
     assert all(df["bad_float"] == np.array([1.1, 9007199254740992, 3.3], dtype=np.float32))
     # However bad string is recognized as int64:
-    assert all(df["bad_string"] == np.array([1, 2, 3], dtype=object))
+    assert all(df["bad_string"] == np.array([1, 2, 3], dtype=np.object))
 
     # Boolean is forced - zero and empty string is false, everything else is true:
-    assert df["bad_boolean"].dtype == bool
+    assert df["bad_boolean"].dtype == np.bool
     assert all(df["bad_boolean"] == [True, False, True])
 
 
@@ -537,7 +537,7 @@ def test_serving_model_with_schema(pandas_df_with_all_types):
         )
         response_json = json.loads(response.content)
 
-        # objects are not converted to pandas Strings at the moment
+        # np.objects are not converted to pandas Strings at the moment
         expected_types = {**pandas_df_with_all_types.dtypes, "string": np.dtype(object)}
         assert response_json == [[k, str(v)] for k, v in expected_types.items()]
         response = pyfunc_serve_and_score_model(
@@ -600,11 +600,14 @@ def test_parse_json_input_including_path():
 @pytest.mark.parametrize(
     "args, expected",
     [
-        ({"port": 5000, "host": "0.0.0.0", "nworkers": 4}, "--timeout=60 -b 0.0.0.0:5000 -w 4"),
-        ({"host": "0.0.0.0", "nworkers": 4}, "--timeout=60 -b 0.0.0.0 -w 4"),
-        ({"port": 5000, "nworkers": 4}, "--timeout=60 -w 4"),
-        ({"nworkers": 4}, "--timeout=60 -w 4"),
-        ({}, "--timeout=60"),
+        (
+            {"port": 5000, "host": "0.0.0.0", "nworkers": 4, "timeout": 60},
+            "--timeout=60 -b 0.0.0.0:5000 -w 4",
+        ),
+        ({"host": "0.0.0.0", "nworkers": 4, "timeout": 60}, "--timeout=60 -b 0.0.0.0 -w 4"),
+        ({"port": 5000, "nworkers": 4, "timeout": 60}, "--timeout=60 -w 4"),
+        ({"nworkers": 4, "timeout": 60}, "--timeout=60 -w 4"),
+        ({"timeout": 60}, "--timeout=60"),
     ],
 )
 def test_get_cmd(args: dict, expected: str):


### PR DESCRIPTION
## What changes are proposed in this pull request?

 - https://github.com/mlflow/mlflow/issues/5381

In this PR, a timeout for scoring server is implemented as a cli argument in `mlfow models` command.
This feature is going to support cases e.g. models with custom inference logic, where a request might take more than 60'' to resolve.

Since the default timeout is 60'', a client will probably get a `connection aborted` message such
```
ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```
if the request will not get resolved. 

Eventually the feature is implemented for:
- Local deployments -> `mlflow models serve -t <timeout>`
- Dockerized deployments `mlflow modelbuild_docker -t <timeout>` 
- Deployment to sagemaker -> `mlflow build-and-push-container -t <timeout>`

## How is this patch tested?

> train_custom_model.py
```
import time
import os

from mlflow.tracking import MlflowClient
from sklearn.linear_model import LogisticRegression

import mlflow
import mlflow.sklearn

class CustomPredict(mlflow.pyfunc.PythonModel):
    def __init__(self) -> None:
        """Custom pyfunc class used to create customized mlflow models
        """

    def load_context(self, context):

        self.model = mlflow.sklearn.load_model(context.artifacts["custom_model"])

    def predict(self, context, model_input): 

        time.sleep(5)
        prediction = self.model.predict(model_input)
        
        return prediction

# create an mlflow client
client = MlflowClient()

model_name = "basic_model"    
custom_model_name = "custom_model"

with mlflow.start_run(run_name="test_pyfunc") as train_run:

    regression_model = LogisticRegression().fit([[1],[0]], [2, 1])

    mlflow.sklearn.log_model(
        sk_model=regression_model,
        artifact_path="model",
        registered_model_name=model_name
    )    
    
    # start a child run to create custom model
    with mlflow.start_run(run_name="test_custom_model", nested=True) as run:

        # create the custom model artifact
        model_uri = os.path.join(train_run.info.artifact_uri, "model")
        custom_model_artifact = {custom_model_name: model_uri}

        # log a custom model
        mlflow.pyfunc.log_model(
            artifact_path="",
            artifacts=custom_model_artifact,
            python_model=CustomPredict(),
            registered_model_name=custom_model_name,
        )    
    
        # load the latest model version
        for mv in client.get_latest_versions(custom_model_name, ["None"]):
            model_version = mv.version

        # transition model to production
        client.transition_model_version_stage(
            name=custom_model_name, version=model_version, stage="Production", archive_existing_versions=True
        )    
```
1) Start mlflow server and run the code

```
mlflow server --backend-store-uri sqlite:///mlflow.sqlite --default-artifact-root mlruns
python train_custom_model.py
````
2) Serve the model with a **timeout** > `time.sleep(5)` to ensure the model responds 
```
mlflow models serve -m "models:/custom_model/Production" -p 5001 --no-conda -t 6  
curl http://127.0.0.1:5001/invocations -H 'Content-Type: application/json; format=pandas-records' -d '[[1], [0]]'
```

3) Serve the model with a **timeout** < `time.sleep(5)` to ensure the model will not respond
```
mlflow models serve -m "models:/custom_model/Production" -p 5001 --no-conda -t 2
curl http://127.0.0.1:5001/invocations -H 'Content-Type: application/json; format=pandas-records' -d '[[1], [0]]'
```

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

[Scoring] Add support to set a custom timeout for a request to resolve on scoring server, in `mlfow models` cli.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
